### PR TITLE
Updating fusion post from Dev Branch

### DIFF
--- a/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
+++ b/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
@@ -58,6 +58,7 @@ maximumCircularSweep = toRad(180);
 
 allowHelicalMoves = true;
 allowedCircularPlanes = undefined; // allow any circular motion
+highFeedrate = (unit == MM) ? 3000 : 140;
 
 // user-defined properties
 properties = {

--- a/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
+++ b/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
@@ -134,15 +134,7 @@ properties = {
     ],
     value: "none",
     scope: "post"
-  },
-  useShankSizeForManualChange: {
-    title      : "Write Manual Tool Changes when Shank Size Changes",
-    description: "",
-    group      : "preferences",
-    type       : "boolean",
-    value      : true,
-    scope      : "post"
-  },
+  }
 };
 
 // wcs definiton
@@ -154,7 +146,6 @@ wcsDefinitions = {
 };
 
 var numberOfToolSlots = 9999;
-var previousToolChangeWasManual = false;
 var subprograms = new Array();
 
 var singleLineCoolant = false; // specifies to output multiple coolant codes in one line rather than in separate lines
@@ -824,122 +815,27 @@ function onSection() {
       warning(localize("Tool number exceeds maximum value."));
     }
 
-    
+    writeToolBlock("T" + toolFormat.format(tool.number), mFormat.format(6));
 
-
-
-    if (tool.number > 6 || tool.manualToolChange) {
-      writeComment("Manual Tool Change To #" + toolFormat.format(tool.number));
-	  if (tool.manualToolChange) {
-		writeComment("as a result of manual tool change selected in tool settings");
-	  }
-
-      if (tool.comment) {
-        writeComment(tool.comment);
-      }
-
-      writeComment("Setup for tool change");
-      if (previousToolChangeWasManual ||  isFirstSection()){
-        writeBlock("G28");
-        writeComment("Paused. Prepare to remove tool from collet. Pressing play will release collet");
-        writeBlock(mFormat.format(27));
-        writeBlock(mFormat.format(600));
-        writeBlock("M490.2 (Open Collet)");
-
-      } else {
-        writeBlock("T-1 M6");
-        writeBlock("G28");
-      }
-
-
-      previousToolChangeWasManual = true;
-
-      writeComment("Paused. Prepare to add new tool to collet. Pressing play will close collet");
-      writeBlock(mFormat.format(27));
-      writeBlock(mFormat.format(600));
-      writeBlock("M490.1 (Close Collet)");
-      writeComment("Paused. Pressing play will calibrate the tool length and continue the program");
-      writeBlock(mFormat.format(27));
-      writeBlock(mFormat.format(600));
-      writeBlock("M493.2T1 (Set tool number to 1 so TLO can be set)");
-      writeBlock("M491 (Calibrate Tool Length)");
-
-    
-
-
-    } else if ((!isFirstSection() && getProperty("useShankSizeForManualChange") && Math.abs(tool.shaftDiameter - getPreviousSection().getTool().shaftDiameter)  >  0.001)){
-        
-        writeComment("Manual Tool Change To #" + toolFormat.format(tool.number));
-		    writeComment("as a result of tool shank size change");
-
-        if (tool.comment) {
-          writeComment(tool.comment);
-        }
-
-
-        if (previousToolChangeWasManual ||  isFirstSection()){
-        writeBlock("G28");
-        writeComment("Paused. Prepare to remove tool from collet. Pressing play will release collet");
-        writeBlock(mFormat.format(27));
-        writeBlock(mFormat.format(600));
-        writeBlock("M490.2 (Open Collet)");
-
-      } else {
-        writeBlock("T-1 M6");
-        writeBlock("G28");
-      }
-
-      previousToolChangeWasManual = true;
-      writeComment("Paused. Prepare to add new tool to collet. Pressing play will close collet");
-      writeBlock(mFormat.format(27));
-      writeBlock(mFormat.format(600));
-      writeBlock("M490.1 (Close Collet)");
-      writeComment("Paused. Pressing play will calibrate the tool length and continue the program");
-      writeBlock(mFormat.format(27));
-      writeBlock(mFormat.format(600));
-      writeBlock("M493.2T" + toolFormat.format(tool.number));
-      writeBlock("M491 (Calibrate Tool Length)");
-      
-
-    } else {
-        if (previousToolChangeWasManual) {
-		  writeComment("Manual Tool Removal as a result of previous manual tool change");
-          writeComment("setup for tool change");
-          writeBlock("G28");
-          writeComment("Paused. Prepare to remove tool from collet. Pressing play will release collet");
-          writeBlock(mFormat.format(27));
-          writeBlock(mFormat.format(600));
-          writeBlock("M490.2");
-          writeComment("Paused. Pressing play will resume program. The program expects an empty collet after this point.");
-          writeBlock(mFormat.format(27));
-          writeBlock(mFormat.format(600));
-          writeBlock("M493.2 T-1");
-          
-        }
-        writeToolBlock("T" + toolFormat.format(tool.number), mFormat.format(6));
-
-        if (tool.comment) {
-          writeComment(tool.comment);
-        }
-        previousToolChangeWasManual = false;
-        var showToolZMin = false;
-        if (showToolZMin) {
-          if (is3D()) {
-            var numberOfSections = getNumberOfSections();
-            var zRange = currentSection.getGlobalZRange();
-            var number = tool.number;
-            for (var i = currentSection.getId() + 1; i < numberOfSections; ++i) {
-              var section = getSection(i);
-              if (section.getTool().number != number) {
-                break;
-              }
-              zRange.expandToRange(section.getGlobalZRange());
-            }
-            writeComment(localize("ZMIN") + "=" + zRange.getMinimum());
+    if (tool.comment) {
+      writeComment(tool.comment);
+    }
+    var showToolZMin = false;
+    if (showToolZMin) {
+      if (is3D()) {
+        var numberOfSections = getNumberOfSections();
+        var zRange = currentSection.getGlobalZRange();
+        var number = tool.number;
+        for (var i = currentSection.getId() + 1; i < numberOfSections; ++i) {
+          var section = getSection(i);
+          if (section.getTool().number != number) {
+            break;
           }
+          zRange.expandToRange(section.getGlobalZRange());
         }
+        writeComment(localize("ZMIN") + "=" + zRange.getMinimum());
       }
-    
+    }
   }
 
   var spindleChanged = tool.type != TOOL_PROBE &&
@@ -1430,5 +1326,4 @@ function onClose() {
   if (isRedirecting()) {
     closeRedirection();
   }
-  previousToolChangeWasManual = false;
 }


### PR DESCRIPTION
New changes: 
1. Bugfix: split file by toolpath not writing M6T# and G90 G17 etc to each file
2. Bugfix: highfeedrate value was unset leading to erroneous F0 commands
3. Feature Improvement: Manual toolchanges are now supported in multiple formats and can be chosen in a dropdown in the post processor settings. 

Carvera Air Toolchanges: All tool numbers are sent direct to the machine, the machine handles changing. 
Error on more than 6 tools: For the full size carvera, does not post files with tool numbers >6
Fusion Manual tool changes: Manual tool changes that work with stock firmware. Any tool number >6, tool marked for manual tool change, or tool with a different shank size will trigger a manual tool change and walk you through the steps. Adding TLO:M to the comment of the tool post processor as shown in the image will allow you to bypass automatic tool length offset measurement and instead leave the machine paused after the tool change. 

Carvera Community Tool Changes: Requires the community firmware here:
https://github.com/Carvera-Community/Carvera_Community_Firmware/releases
Allows tools 0-99. If the tool number is >6 the machine will walk you through a manual tool change. Look for instructions in the MDI
Adding TLO:M to the comment of the tool post processor as shown in the image will allow you to bypass automatic tool length offset measurement and instead leave the machine paused after the tool change. 
Adding TLO:-14 will set the TLO for the tool to -14

By default both manual tool change setups will automatically perform a tool length measurement after the tool change is complete. 



<img width="605" alt="image" src="https://github.com/user-attachments/assets/3740f1c3-16a6-4a42-ae7c-1c6cc579df26">
