### PR TITLE
chore: add a comment before the manual stop command

### DIFF
--- a/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
+++ b/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
@@ -1358,6 +1358,7 @@ var mapCommand = {
 function onCommand(command) {
   switch (command) {
   case COMMAND_STOP:
+    writeComment("Stop");
     writeBlock(mFormat.format(600));
     forceSpindleSpeed = true;
     forceCoolant = true;


### PR DESCRIPTION
It makes it easier to verify the gcode and see what's happening during the execution.