### PR TITLE
Fusion 360 Post Processor: Add more info to tool headers

### DIFF
--- a/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
+++ b/CAM_Post_Processors/Fusion360-profiles/Carvera.cps
@@ -358,6 +358,14 @@ function getToolShaftDiameterMm(tool) {
 }
 
 /**
+  Shaft diameter in current document units.
+*/
+function getShaftDiameter(tool) {
+  var diaMm = getToolShaftDiameterMm(tool);
+  return (unit == MM) ? diaMm : (diaMm / 25.4);
+}
+
+/**
   Returns S1-S5 parameter for tool change when shank diameter changed.
   DO NOT CHANGE THIS NUMBERING: S1=3.175mm, S2=4mm, S3=6mm, S4=6.35mm, S5=8mm.
   diameterMm in mm. Returns "" if no match.
@@ -566,44 +574,77 @@ function getBodyLength(tool) {
   return tool.bodyLength + tool.holderLength;
 }
 
+/**
+  Append " KEY=value" when value is a finite number.
+  By default requires value > 0; pass allowZero=true to also accept 0 (e.g. tip diameter).
+*/
+function appendToolField(comment, key, value, format, allowZero) {
+  if (typeof value != "number" || isNaN(value)) {
+    return comment;
+  }
+  if (allowZero ? value < 0 : value <= 0) {
+    return comment;
+  }
+  return comment + " " + key + "=" + format.format(value);
+}
+
+/**
+  Dump one comment line per tool for the header tool list.
+
+  Layout:
+  T<n>  <description>  <vendor>  <productId>  D=<diameter>
+    [CR=<corner radius>] [SD=<shaft>] [TD=<tip>] [FL=<flute>] [SL=<shoulder>]
+    [BL=<body>] [TP=<pitch>] [TAPER=<angle>deg] [- ZMIN=<z>] - <toolTypeName>
+
+  See https://cam.autodesk.com/posts/reference/classTool.html
+*/
 function dumpToolInformation() {
-    // dump tool information
+  var zRanges = {};
+  if (is3D()) {
+    var numberOfSections = getNumberOfSections();
+    for (var i = 0; i < numberOfSections; ++i) {
+      var section = getSection(i);
+      var zRange = section.getGlobalZRange();
+      var sectionTool = section.getTool();
+      if (zRanges[sectionTool.number]) {
+        zRanges[sectionTool.number].expandToRange(zRange);
+      } else {
+        zRanges[sectionTool.number] = zRange;
+      }
+    }
+  }
 
-      var zRanges = {};
-      if (is3D()) {
-        var numberOfSections = getNumberOfSections();
-        for (var i = 0; i < numberOfSections; ++i) {
-          var section = getSection(i);
-          var zRange = section.getGlobalZRange();
-          var tool = section.getTool();
-          if (zRanges[tool.number]) {
-            zRanges[tool.number].expandToRange(zRange);
-          } else {
-            zRanges[tool.number] = zRange;
-          }
-        }
+  var tools = getToolTable();
+  if (tools.getNumberOfTools() > 0) {
+    for (var i = 0; i < tools.getNumberOfTools(); ++i) {
+      var tool = tools.getTool(i);
+      var comment = "T" + toolFormat.format(tool.number) + "  " +
+        tool.description + "  " +
+        tool.vendor + "  " +
+        tool.productId + "  " +
+        "D=" + xyzFormat.format(tool.diameter);
+
+      // Extra geometry
+      comment = appendToolField(comment, "CR", tool.cornerRadius, xyzFormat);
+      comment = appendToolField(comment, "SD", getShaftDiameter(tool), xyzFormat);
+      comment = appendToolField(comment, "TD", tool.tipDiameter, xyzFormat, true);
+      comment = appendToolField(comment, "FL", tool.fluteLength, xyzFormat);
+      comment = appendToolField(comment, "SL", tool.shoulderLength, xyzFormat);
+      comment = appendToolField(comment, "BL", tool.bodyLength, xyzFormat);
+      comment = appendToolField(comment, "TP", tool.threadPitch, xyzFormat);
+
+      if ((tool.taperAngle > 0) && (tool.taperAngle < Math.PI)) {
+        comment += " TAPER=" + taperFormat.format(tool.taperAngle) + "deg";
       }
 
-      var tools = getToolTable();
-      if (tools.getNumberOfTools() > 0) {
-        for (var i = 0; i < tools.getNumberOfTools(); ++i) {
-          var tool = tools.getTool(i);
-          var comment = "T" + toolFormat.format(tool.number) + "  " +
-            tool.description + "  " +
-            tool.vendor + "  " +
-            tool.productId + "  " +
-            "D=" + xyzFormat.format(tool.diameter) + " " +
-            localize("CR") + "=" + xyzFormat.format(tool.cornerRadius);
-          if ((tool.taperAngle > 0) && (tool.taperAngle < Math.PI)) {
-            comment += " " + localize("TAPER") + "=" + taperFormat.format(tool.taperAngle) + localize("deg");
-          }
-          if (zRanges[tool.number]) {
-            comment += " - " + localize("ZMIN") + "=" + xyzFormat.format(zRanges[tool.number].getMinimum());
-          }
-          comment += " - " + getToolTypeName(tool.type);
-          writeComment(comment);
-        }
+      if (zRanges[tool.number]) {
+        comment += " - ZMIN=" + xyzFormat.format(zRanges[tool.number].getMinimum());
       }
+
+      comment += " - " + getToolTypeName(tool.type);
+      writeComment(comment);
+    }
+  }
 }
 
 function defineMachine() {


### PR DESCRIPTION
Related to https://github.com/Carvera-Community/Carvera_Controller/pull/685

Adds a few fields to the tools dump of the Fusion post processor:
* `CR`: Corner radius (already existed before, but it will now only be added if non-zero)
* `SD`: Shaft diameter. I reused the logic that determines the collet sized for M6 calls, but converted back to document unit
* `TD`: Tip diameter
* `FL`: Flute length
* `SL`: Shoulder length
* `BL`: Body length
* `TP`: Thread pitch

Note that the existing fields won't be localized anymore so they can be parsed reliably.

**Before:**

```
(T1  3 Flute Roughing DLC - 6*15mm  BB Tools    D=6. CR=0. - ZMIN=-5.5 - flat end mill)
(T2  3 Flute DLC - 6*12mm  BB Tools    D=6. CR=0. - ZMIN=-5.5 - flat end mill)
(T3  2 Flute Chamber Endmill 6mm 45? DLC  Chowmaster    D=6. CR=0. TAPER=45deg - ZMIN=-1.75 - chamfer mill)
(T4  1 Flute DLC - 3*17mm  Dreanique    D=3. CR=0. - ZMIN=-17. - flat end mill)
(T5  1 Flute DLC - 2*10mm  Dreanique    D=2. CR=0. - ZMIN=-9. - flat end mill)
(T10  Carvera M3 Threadmill      D=2.42 CR=0. - ZMIN=-8.863 - thread mill)
```

**After:**

```
(T1  3 Flute Roughing DLC - 6*15mm  BB Tools    D=6. SD=6. TD=0. FL=15. SL=17. BL=17. - ZMIN=-5.5 - flat end mill)
(T2  3 Flute DLC - 6*12mm  BB Tools    D=6. SD=6. TD=0. FL=12. SL=17. BL=17. - ZMIN=-5.5 - flat end mill)
(T3  2 Flute Chamber Endmill 6mm 45? DLC  Chowmaster    D=6. SD=6. TD=0. FL=12. SL=20. BL=20. TAPER=45deg - ZMIN=-1.75 - chamfer mill)
(T4  1 Flute DLC - 3*17mm  Dreanique    D=3. SD=6. TD=0. FL=17. SL=17. BL=20. - ZMIN=-17. - flat end mill)
(T5  1 Flute DLC - 2*10mm  Dreanique    D=2. SD=6. TD=0. FL=10. SL=10. BL=14. - ZMIN=-9. - flat end mill)
(T10  Carvera M3 Threadmill      D=2.42 SD=3.175 TD=0. FL=2. SL=9. BL=28. TP=0.5 - ZMIN=-5.307 - thread mill)
```